### PR TITLE
Add SSL suppport

### DIFF
--- a/create_debmatic.sh
+++ b/create_debmatic.sh
@@ -123,6 +123,15 @@ done
 
 cd $WORK_DIR
 
+openssl req -new -x509 -nodes -keyout $WORK_DIR/server.pem \
+                                              -out $WORK_DIR/server.pem \
+                                              -days 3650 \
+                                              -addext "subjectAltName = DNS:debmatic" \
+                                              -addext "keyUsage = keyCertSign,digitalSignature,keyEncipherment" \
+                                              -addext "extendedKeyUsage = serverAuth" \
+                                              -addext "nsCertType = server,sslCA" \
+                                              -subj "/CN=debmatic" 2>/dev/null >/dev/null
+
 declare -A architectures=(["armhf"]="arm-gnueabihf" ["arm64"]="arm-gnueabihf" ["i386"]="X86_32_Debian_Wheezy" ["amd64"]="X86_32_Debian_Wheezy")
 for ARCH in "${!architectures[@]}"
 do
@@ -168,14 +177,7 @@ do
 
   cp -pR $CURRENT_DIR/debmatic/* $TARGET_DIR 
   
-  openssl req -new -x509 -nodes -keyout $TARGET_DIR/etc/config/server.pem \
-                                              -out $TARGET_DIR/etc/config/server.pem \
-                                              -days 3650 \
-                                              -addext "subjectAltName = DNS:debmatic" \
-                                              -addext "keyUsage = keyCertSign,digitalSignature,keyEncipherment" \
-                                              -addext "extendedKeyUsage = serverAuth" \
-                                              -addext "nsCertType = server,sslCA" \
-                                              -subj "/CN=debmatic" 2>/dev/null >/dev/null
+  cp $WORK_DIR/server.pem $TARGET_DIR/etc/config_templates/
 
   echo "VERSION=$CCU_VERSION.$PKG_BUILD" > $TARGET_DIR/usr/share/debmatic/VERSION
 

--- a/create_debmatic.sh
+++ b/create_debmatic.sh
@@ -167,6 +167,15 @@ do
   cp -pR $WORK_DIR/ccu/www $TARGET_DIR/
 
   cp -pR $CURRENT_DIR/debmatic/* $TARGET_DIR 
+  
+  openssl req -new -x509 -nodes -keyout $TARGET_DIR/etc/config/server.pem \
+                                              -out $TARGET_DIR/etc/config/server.pem \
+                                              -days 3650 \
+                                              -addext "subjectAltName = DNS:debmatic" \
+                                              -addext "keyUsage = keyCertSign,digitalSignature,keyEncipherment" \
+                                              -addext "extendedKeyUsage = serverAuth" \
+                                              -addext "nsCertType = server,sslCA" \
+                                              -subj "/CN=debmatic" 2>/dev/null >/dev/null
 
   echo "VERSION=$CCU_VERSION.$PKG_BUILD" > $TARGET_DIR/usr/share/debmatic/VERSION
 

--- a/debmatic/etc/debmatic/webui.conf
+++ b/debmatic/etc/debmatic/webui.conf
@@ -1,1 +1,2 @@
 var.debmatic_webui_http_port = 80
+var.debmatic_webui_https_port = 443

--- a/debmatic/etc/lighttpd/conf-available/20-debmatic.conf
+++ b/debmatic/etc/lighttpd/conf-available/20-debmatic.conf
@@ -1,5 +1,8 @@
 server.max-request-field-size = 65536
-server.modules   += ( "mod_proxy" )
+server.modules   += ( 
+        "mod_proxy",
+        "mod_openssl"        
+)
 
 include "/etc/debmatic/webui.conf"
 
@@ -21,6 +24,41 @@ $SERVER["socket"] == ":" + var.debmatic_webui_http_port {
   proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 30080)))
 }
 $SERVER["socket"] == "[::]:" + var.debmatic_webui_http_port {
+  server.errorfile-prefix    = "/www/error/error-"
+  server.document-root = "/www"
+
+  $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
+    $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
+      url.access-deny = ( "" )
+    }
+  }
+  $HTTP["url"] !~ "^/(config/)|(upnp/)|(webui/)|(ise/)|(api/)|(tools/)|(pda)|(pages/jpages)|(addons).*" {
+    proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 8183)))
+  }
+  $HTTP["url"] =~ "^/(pages/jpages).*" {
+    proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 39292)))
+  }
+  proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 30080)))
+}
+
+$SERVER["socket"] == ":" + var.debmatic_webui_https_port {
+  server.errorfile-prefix    = "/www/error/error-"
+  server.document-root = "/www"
+
+  $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
+    $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
+      url.access-deny = ( "" )
+    }
+  }
+  $HTTP["url"] !~ "^/(config/)|(upnp/)|(webui/)|(ise/)|(api/)|(tools/)|(pda)|(pages/jpages)|(addons).*" {
+    proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 8183)))
+  }
+  $HTTP["url"] =~ "^/(pages/jpages).*" {
+    proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 39292)))
+  }
+  proxy.server = ( "" => ("localhost" => ("host" => "127.0.0.1", "port" => 30080)))
+}
+$SERVER["socket"] == "[::]:" + var.debmatic_webui_https_port {
   server.errorfile-prefix    = "/www/error/error-"
   server.document-root = "/www"
 

--- a/debmatic/etc/lighttpd/conf-available/20-debmatic.conf
+++ b/debmatic/etc/lighttpd/conf-available/20-debmatic.conf
@@ -26,6 +26,7 @@ $SERVER["socket"] == ":" + var.debmatic_webui_http_port {
 $SERVER["socket"] == "[::]:" + var.debmatic_webui_http_port {
   server.errorfile-prefix    = "/www/error/error-"
   server.document-root = "/www"
+  server.use-ipv6 = "enable"
 
   $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
     $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
@@ -44,6 +45,7 @@ $SERVER["socket"] == "[::]:" + var.debmatic_webui_http_port {
 $SERVER["socket"] == ":" + var.debmatic_webui_https_port {
   server.errorfile-prefix    = "/www/error/error-"
   server.document-root = "/www"
+  include "/etc/debmatic/lighttpd/conf.d/sslsettings.conf"
 
   $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
     $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {
@@ -61,6 +63,8 @@ $SERVER["socket"] == ":" + var.debmatic_webui_https_port {
 $SERVER["socket"] == "[::]:" + var.debmatic_webui_https_port {
   server.errorfile-prefix    = "/www/error/error-"
   server.document-root = "/www"
+  server.use-ipv6 = "enable"
+  include "/etc/debmatic/lighttpd/conf.d/sslsettings.conf"
 
   $HTTP["url"] =~ "^/.*\.(exe|oxml|hssml).*" {
     $HTTP["remoteip"] !~ "^(127\.0\.0\.1|::ffff:127\.0\.0\.1|::1)$" {


### PR DESCRIPTION
This adds SSL support to debmatic ( #3 )
Self signed certificate is created at build time.
Certificate in `/etc/config/server.pem` can be replaced with Lets Encrypt certificates by the user.
Afterwards `systemctl reload lighttpd` has to be called.