### PR TITLE
Use /sys/class/raw-uart/

### DIFF
--- a/debmatic-lxc-host/usr/share/debmatic/bin/lxc-start-hook.sh
+++ b/debmatic-lxc-host/usr/share/debmatic/bin/lxc-start-hook.sh
@@ -86,8 +86,8 @@ do
     UART_DEV="raw-uart$dev_no"
   fi
 
-  if [ -e "/sys/devices/virtual/raw-uart/$UART_DEV" ]; then
-    allow_device `cat /sys/devices/virtual/raw-uart/$UART_DEV/dev`
+  if [ -e "/sys/class/raw-uart/$UART_DEV" ]; then
+    allow_device `cat /sys/class/raw-uart/$UART_DEV/dev`
   fi
 done
 


### PR DESCRIPTION
`/sys/devices/virtual/raw-uart` may not exists everywhere (depending on the kernel version). RaspberryMatic replaced all paths in https://github.com/jens-maus/RaspberryMatic/commit/cafe9a36b0251d4e313cfadc6284cbf4e1a901fb. We should do the same for the lxc start hook script.