### PR TITLE
Hinzufügen eines debmatic-restore.sh script und debmatic-backup.sh sichert zusätzlich "/usr/local/addons"

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ sudo debmatic-backup
 ```
 Dieses Backup enthält nur die Einstellungen der CCU und ersetzt daher nicht ein Backup des Gesamtsystems.
 
+### Restore
+Ein Restore kann entweder über die WebUI erfolgen oder auf der Konsole über
+```bash
+sudo debmatic-restore $BACKUPFILE
+```
+
 ### Addons
 Addons können per apt installiert werden. Aktuell exitieren folgende Addons:
 * [Cloudmatic Connect](https://www.cloudmatic.de) (Paketname cloudmatic)

--- a/debmatic/DEBIAN/postinst
+++ b/debmatic/DEBIAN/postinst
@@ -15,6 +15,9 @@ case "$1" in
     if [ ! -e /usr/sbin/debmatic-backup ]; then
       ln -s /usr/share/debmatic/bin/debmatic-backup.sh /usr/sbin/debmatic-backup
     fi
+    if [ ! -e /usr/sbin/debmatic-restore ]; then
+      ln -s /usr/share/debmatic/bin/debmatic-restore.sh /usr/sbin/debmatic-restore
+    fi
 
     cp /usr/share/debmatic/VERSION /boot/VERSION
 

--- a/debmatic/usr/share/debmatic/bin/debmatic-backup.sh
+++ b/debmatic/usr/share/debmatic/bin/debmatic-backup.sh
@@ -24,7 +24,7 @@ fi
 TMPDIR=`mktemp -d`
 
 cd /
-tar czf $TMPDIR/usr_local.tar.gz etc/config --transform 's/^/usr\/local\//g'
+tar czf $TMPDIR/usr_local.tar.gz usr/local/addons etc/config --transform 's/^/usr\/local\//g'
 
 crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
 crypttool -g -t 1 > $TMPDIR/key_index

--- a/debmatic/usr/share/debmatic/bin/debmatic-backup.sh
+++ b/debmatic/usr/share/debmatic/bin/debmatic-backup.sh
@@ -24,7 +24,7 @@ fi
 TMPDIR=`mktemp -d`
 
 cd /
-tar czf $TMPDIR/usr_local.tar.gz usr/local/addons etc/config --transform 's/^/usr\/local\//g'
+tar czf $TMPDIR/usr_local.tar.gz etc/config --transform 's/^/usr\/local\//g'
 
 crypttool -s -t 1 < $TMPDIR/usr_local.tar.gz > $TMPDIR/signature
 crypttool -g -t 1 > $TMPDIR/key_index

--- a/debmatic/usr/share/debmatic/bin/debmatic-restore.sh
+++ b/debmatic/usr/share/debmatic/bin/debmatic-restore.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+if [ $EUID != 0 ]; then
+  echo "Please run as root"
+  exit
+fi
+
+if [ $# -ne 1 ] || [ ! -f "$1" ]; then
+  echo "debmatic-restore <backupfile>"
+  exit 1
+fi
+
+CURDIR=`pwd`
+
+BACKUPFILE=`realpath $1`
+
+if [ `systemctl is-active debmatic-rega.service` == "active" ]; then
+  echo "load tclrega.so; rega system.Save()" | /bin/tclsh
+fi
+
+TMPDIR=`mktemp -d`
+
+systemctl stop debmatic.service
+
+tar --warning=no-timestamp --no-same-owner -xf $BACKUPFILE -C $TMPDIR/
+
+# extract usr_local.tar.gz but make sure NOT to unarchive anything outside
+tar -xf $TMPDIR/usr_local.tar.gz --warning=no-timestamp --no-same-owner --strip-components=2 -C /
+
+rm /etc/config/localtime
+ln -s /usr/share/zoneinfo/Europe/Berlin localtime
+
+cd $CURDIR
+rm -rf $TMPDIR
+
+sync
+
+systemctl start debmatic.service
+
+echo "Backup from $BACKUPFILE restored"
+


### PR DESCRIPTION
Ich schreibe zur Zeit eine ansible role für debmatic und wollte diese um eine restore Funktion erweitern, sollte ein Backup vorhanden sein.
Dabei ist mir zum einen aufgefallen, dass u.a. die addons in "/usr/local/addons" nicht im Backup liegen und habe dafür das script "debmatic-backup.sh" leicht überarbeitet.
Zusätzlich brauchte ich ein "debmatic-restore.sh", welches ich via ansible zum restore des Backups nutzen kann. 
Ich habe mich am original "debmatic-backup.sh" orientiert, ein "debmatic-restore.sh" geschrieben und das auch soweit in die Installationsroutine aufgenommen.

Das "debmatic-restore.sh" habe ich bislang nur in meinem eigenen System erfolgreich testen können. Es wären weitere Tests sinnvoll, denke ich.