### PR TITLE
Build packages as non-root user

### DIFF
--- a/addons/cloudmatic/create_cloudmatic.sh
+++ b/addons/cloudmatic/create_cloudmatic.sh
@@ -23,7 +23,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build cloudmatic-$PKG_VERSION
+fakeroot dpkg-deb --build cloudmatic-$PKG_VERSION
 
 cp cloudmatic-*.deb $CURRENT_DIR
 

--- a/addons/cuxd/create_cuxd.sh
+++ b/addons/cuxd/create_cuxd.sh
@@ -46,7 +46,7 @@ do
 
   cd $WORK_DIR
 
-  dpkg-deb --build cuxd-$PKG_VERSION-$ARCH
+  fakeroot dpkg-deb --build cuxd-$PKG_VERSION-$ARCH
 done
 
 cp cuxd-*.deb $CURRENT_DIR

--- a/addons/hb-sen-ljet/create_hb-sen-ljet.sh
+++ b/addons/hb-sen-ljet/create_hb-sen-ljet.sh
@@ -44,7 +44,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build hb-sen-ljet-$PKG_VERSION
+fakeroot dpkg-deb --build hb-sen-ljet-$PKG_VERSION
 
 cp hb-sen-ljet-*.deb $CURRENT_DIR
 

--- a/addons/hb-uni-sensor1/create_hb-uni-sensor1.sh
+++ b/addons/hb-uni-sensor1/create_hb-uni-sensor1.sh
@@ -44,7 +44,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build hb-uni-sensor1-$PKG_VERSION
+fakeroot dpkg-deb --build hb-uni-sensor1-$PKG_VERSION
 
 cp hb-uni-sensor1-*.deb $CURRENT_DIR
 

--- a/addons/homematic-check-mk/create_homematic-check-mk.sh
+++ b/addons/homematic-check-mk/create_homematic-check-mk.sh
@@ -23,7 +23,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build homematic-check-mk-$PKG_VERSION
+fakeroot dpkg-deb --build homematic-check-mk-$PKG_VERSION
 
 cp homematic-check-mk-*.deb $CURRENT_DIR
 

--- a/addons/jp-hb-devices/create_jp-hb-devices.sh
+++ b/addons/jp-hb-devices/create_jp-hb-devices.sh
@@ -32,7 +32,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build jp-hb-devices-$PKG_VERSION
+fakeroot dpkg-deb --build jp-hb-devices-$PKG_VERSION
 
 cp jp-hb-devices-*.deb $CURRENT_DIR
 

--- a/addons/xml-api/create_xml-api.sh
+++ b/addons/xml-api/create_xml-api.sh
@@ -33,7 +33,7 @@ done
 
 cd $WORK_DIR
 
-dpkg-deb --build xml-api-$PKG_VERSION
+fakeroot dpkg-deb --build xml-api-$PKG_VERSION
 
 cp xml-api-*.deb $CURRENT_DIR
 

--- a/create_debmatic.sh
+++ b/create_debmatic.sh
@@ -38,13 +38,8 @@ tar xzf ccu3.tar.gz
 
 gunzip rootfs.ext4.gz
 
-mkdir $WORK_DIR/image
-mount -t ext4 -o loop,ro rootfs.ext4 $WORK_DIR/image
-
 mkdir $WORK_DIR/ccu
-cp -pR $WORK_DIR/image/* $WORK_DIR/ccu/
-
-umount $WORK_DIR/image
+7z x -o$WORK_DIR/ccu rootfs.ext4
 
 cd $WORK_DIR/ccu
 patch -E -l -p1 < $CURRENT_DIR/debmatic.patch
@@ -194,7 +189,7 @@ EOF
 
   cd $WORK_DIR
 
-  dpkg-deb --build -Zxz debmatic-$PKG_VERSION-$ARCH
+  fakeroot dpkg-deb --build -Zxz debmatic-$PKG_VERSION-$ARCH
 done
 
 cp debmatic-*.deb $CURRENT_DIR

--- a/create_debmatic_lxc_host.sh
+++ b/create_debmatic_lxc_host.sh
@@ -19,7 +19,7 @@ for file in $TARGET_DIR/DEBIAN/*; do
   sed -i "s/{PKG_VERSION}/$PKG_VERSION/g" $file
 done
 
-dpkg-deb --build debmatic-lxc-host-$PKG_VERSION
+fakeroot dpkg-deb --build debmatic-lxc-host-$PKG_VERSION
 
 cp debmatic-*.deb $CURRENT_DIR
 


### PR DESCRIPTION
* Use 7z to extract rootfs.ext4, instead of mounting the ext4, what can only be done with root permissions.
* Use fakeroot for dpkg-deb, so that archived files belong to root/root.

Signed-off-by: Alexander Irion <alexirion@web.de>