### PR TITLE
hmserver: Fix setting log4j configuration

### DIFF
--- a/create_debmatic.sh
+++ b/create_debmatic.sh
@@ -15,7 +15,7 @@ JP_HB_DEVICES_ADDON_DOWNLOAD_URL="https://github.com/jp112sdl/JP-HB-Devices-addo
 HB_TM_DEVICES_ADDON_ARCHIVE_TAG="ab7bdeba2c180d5b6fc453a010d4ee2b882a929d"
 HB_TM_DEVICES_ADDON_DOWNLOAD_URL="https://github.com/TomMajor/SmartHome/archive/$HB_TM_DEVICES_ADDON_ARCHIVE_TAG.tar.gz"
 
-PKG_BUILD=97
+PKG_BUILD=98
 
 CURRENT_DIR=$(pwd)
 WORK_DIR=$(mktemp -d)

--- a/debmatic/usr/share/debmatic/bin/start_hmserver.sh
+++ b/debmatic/usr/share/debmatic/bin/start_hmserver.sh
@@ -20,7 +20,7 @@ else
   fi
 fi
 
-JAVA_HOME=$JAVA_HOME $JAVA_HOME/bin/java -Xmx128m -Dlog4j.configuration=file:///etc/config/log4j2.xml -Dfile.encoding=ISO-8859-1 $JAVA_ARGS -Dgnu.io.rxtx.SerialPorts=$HMSERVER_DEV -cp ${CLAZZPATH}:/opt/HMServer/$HMSERVER_BIN.jar $HMSERVER_ARGS &
+JAVA_HOME=$JAVA_HOME $JAVA_HOME/bin/java -Xmx128m -Dlog4j.configurationFile=file:///etc/config/log4j2.xml -Dfile.encoding=ISO-8859-1 $JAVA_ARGS -Dgnu.io.rxtx.SerialPorts=$HMSERVER_DEV -cp ${CLAZZPATH}:/opt/HMServer/$HMSERVER_BIN.jar $HMSERVER_ARGS &
 echo $! > /var/run/HMIPServer.pid
 
 for i in {1..120}; do


### PR DESCRIPTION
With log4j2 the system property name for the configuration file changed from "configuration" to "configurationFile". See https://logging.apache.org/log4j/2.x/manual/configuration.html.

This issue caused the file /var/log/hmserver.log not beeing created, tested on Raspberry Pi OS 10 (Buster).

Signed-off-by: airion <alexirion@web.de>