### PR TITLE
Fix a lighttpd configuration variable

### DIFF
--- a/debmatic/etc/debmatic/lighttpd/conf.d/global.conf
+++ b/debmatic/etc/debmatic/lighttpd/conf.d/global.conf
@@ -4,4 +4,4 @@
 ##
 ## Requests with a header larger than this will end in a 431 error.
 ##
-server.max-request-field-size = 65536
+server.max-request-field-size = 65535


### PR DESCRIPTION
On recent lighttpd versions (e.g. 1.4.73) the max-request-field-size is a short integer, hence the value of 65536 is out of range and will cause the process to exit with a status=255/EXCEPTION.