### PR TITLE
Neues AddOn HM-Print

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Addons können per apt installiert werden. Aktuell exitieren folgende Addons:
 * [Homematic check_mk addon](https://github.com/alexreinert/homematic_check_mk) (Paketname homematic-check-mk)
 * [HB-TM-Devices](https://github.com/TomMajor/SmartHome) (Ist bereits in debmatic enthalten)
 * [XML-API](https://github.com/jens-maus/XML-API) (Paketname xml-api)
+* [HM-Print](https://github.com/homematic-community/hm-print) aka [ProgrammeDrucken](https://homematic-forum.de/forum/viewtopic.php?f=41&t=19296) (Paketname hm-print)
 
 ### Restore
 Backups können über die WebUI eingespielt werden.

--- a/addons/hm-print/create_hm-print.sh
+++ b/addons/hm-print/create_hm-print.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#set -vx
+
+pkgNAME="hm-print"
+pkgVERSION=2.6
+pkgBUILD="1"
+
+dlURL="https://github.com/homematic-community/${pkgNAME}/releases/download/${pkgVERSION}/${pkgNAME}-${pkgVERSION}.tar.gz"
+
+currDIR="$(pwd)"
+workDIR="$(mktemp -d)"
+
+cd "${workDIR}"
+
+wget -O ${pkgNAME}.tar.gz ${dlURL}
+tar xzf ${pkgNAME}.tar.gz
+rm ${pkgNAME}.tar.gz
+
+targetDIR="${workDIR}/${pkgNAME}-${pkgVERSION}-${pkgBUILD}"
+addonDIR="${targetDIR}/usr/local/addons/${pkgNAME}"
+
+mkdir -p "${addonDIR}"
+cp -a ${workDIR}/addon/* "${addonDIR}"
+cp -a ${workDIR}/rc.d/*  "${addonDIR}"
+cp -a ${workDIR}/www/*   "${addonDIR}"
+
+# inside ${workDIR}/rc.d there is "programmedrucken"
+# we don't need "mount" commands and not RCD_DIR
+# so we can use it inside DEBIAN "postinst" and "prerm" scripts
+sed -i '/mount/d; /RCD_DIR/d' ${addonDIR}/programmedrucken
+chmod 755 ${addonDIR}/programmedrucken
+
+cp -a ${currDIR}/hm-print/* "${targetDIR}"
+
+for sedFILE in ${targetDIR}/DEBIAN/*; do
+    sed -i "s/{PKG_VERSION}/${pkgVERSION}-${pkgBUILD}/g" "${sedFILE}"
+done
+
+cd "${workDIR}"
+
+dpkg-deb --build ${pkgNAME}-${pkgVERSION}-${pkgBUILD}
+
+cp "${pkgNAME}-${pkgVERSION}-${pkgBUILD}.deb" "${currDIR}"
+
+cd ${currDIR}
+rm -R "${workDIR}"
+

--- a/addons/hm-print/hm-print/DEBIAN/control
+++ b/addons/hm-print/hm-print/DEBIAN/control
@@ -1,0 +1,11 @@
+Package: hm-print
+Version: {PKG_VERSION}
+Architecture: all
+Installed-Size: 336
+Maintainer: Various, see Homepage
+Uploader: Christian Schoenebeck <christian.schoenebeck@gmail.com>
+Pre-Depends: debmatic (>= 3.73.9)
+Section: debmatic-addons
+Priority: extra
+Homepage: https://github.com/homematic-community/hm-print
+Description: hm-print addon for debmatic

--- a/addons/hm-print/hm-print/DEBIAN/postinst
+++ b/addons/hm-print/hm-print/DEBIAN/postinst
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+PKGNAME=hm-print
+PKG_DIR=/usr/local/addons/${PKGNAME}
+
+ADDONNAME=print
+ADDON_DIR=/usr/local/etc/config/addons/${ADDONNAME}
+WWW_DIR=/usr/local/etc/config/addons/www/${ADDONNAME}
+
+case "$1" in
+
+    configure)
+        echo "Create links to homematic directories"
+        ln -s ${PKG_DIR} ${ADDON_DIR}
+        ln -s ${PKG_DIR} ${WWW_DIR}
+        # run modified rc.d script
+        echo "Running package's own rc.d script (start)"
+        ${PKG_DIR}/programmedrucken start || exit 1
+        # restart debmatic required
+        echo "Installation done! You need to restart debmatic"
+        echo "run: sudo systemctl restart debmatic"
+        ;;
+
+    *)
+        # ignore reconfigure, abort-upgrade, abort-remove, abort-deconfigure
+        ;;
+
+esac
+

--- a/addons/hm-print/hm-print/DEBIAN/postrm
+++ b/addons/hm-print/hm-print/DEBIAN/postrm
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+PKGNAME=hm-print
+PKG_DIR=/usr/local/addons/${PKGNAME}
+
+ADDONNAME=print
+ADDON_DIR=/usr/local/etc/config/addons/${ADDONNAME}
+WWW_DIR=/usr/local/etc/config/addons/www/${ADDONNAME}
+
+case "$1" in
+
+    remove)
+        # restart debmatic required
+        echo "Remove done! You need to restart debmatic"
+        echo "run: sudo systemctl restart debmatic"
+        ;;
+
+    *)
+        # ignore purge, upgrade, failed-upgrade, abort-install, abort-upgrade, disappear
+        ;;
+
+esac
+

--- a/addons/hm-print/hm-print/DEBIAN/preinst
+++ b/addons/hm-print/hm-print/DEBIAN/preinst
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+PKGNAME=hm-print
+PKG_DIR=/usr/local/addons/${PKGNAME}
+
+ADDONNAME=print
+ADDON_DIR=/usr/local/etc/config/addons/${ADDONNAME}
+WWW_DIR=/usr/local/etc/config/addons/www/${ADDONNAME}
+
+case "$1" in
+
+    upgrade)
+        # if old package exist then reset modified files to original
+        if [ -f ${PKG_DIR}/programmedrucken ]; then
+            echo "Running package's own rc.d script (uninstall)"
+            ${PKG_DIR}/programmedrucken uninstall
+        fi
+        # remove links to homematic directories
+        echo "Remove links to homematic directories"
+        rm ${ADDON_DIR} 2>/dev/null || true
+        rm ${WWW_DIR}   2>/dev/null || true
+        # remove old files
+        echo "Remove old files"
+        rm -fr ${PKG_DIR}
+        ;;
+
+    *)
+        # ignore install, abort-upgrade
+        ;;
+
+esac
+

--- a/addons/hm-print/hm-print/DEBIAN/prerm
+++ b/addons/hm-print/hm-print/DEBIAN/prerm
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+PKGNAME=hm-print
+PKG_DIR=/usr/local/addons/${PKGNAME}
+
+ADDONNAME=print
+ADDON_DIR=/usr/local/etc/config/addons/${ADDONNAME}
+WWW_DIR=/usr/local/etc/config/addons/www/${ADDONNAME}
+
+case "$1" in
+
+    remove)
+        echo "Running package's own rc.d script (uninstall)"
+        ${PKG_DIR}/programmedrucken uninstall || exit 1
+
+        echo "Remove links to homematic directories"
+        rm ${ADDON_DIR} 2>/dev/null || true
+        rm ${WWW_DIR}   2>/dev/null || true
+
+        echo "Removing package files"
+        # done by dpkg
+        ;;
+
+    *)
+        # ignore upgrade, deconfigure, failed-upgrade
+        ;;
+
+esac


### PR DESCRIPTION
Die Script-Datei erzeugt, wie bei XML-API, ein fertiges Debian Paket im entsprechenden Verzeichnis. Als Grundlage dient die Release-Datei aus dem GitHub-Projekt hm-print der homematic-community. https://github.com/homematic-community/hm-print/releases

Bitte die Einträge für Maintainer, Uploader, Homepage in der "control" Datei überprüfen, damit diese den Anforderungen entsprechen.
Wie eine Übertragung des Debian Paketes in das debmatic-Repository erfolgt habe ich leider nicht gefunden.

Getestet unter debmatic 3.73.9.112