### PR TITLE
Apply WebUI-Fix-MissingRouterOption bugfix

### DIFF
--- a/create_debmatic.sh
+++ b/create_debmatic.sh
@@ -15,7 +15,7 @@ JP_HB_DEVICES_ADDON_DOWNLOAD_URL="https://github.com/jp112sdl/JP-HB-Devices-addo
 HB_TM_DEVICES_ADDON_ARCHIVE_TAG="ab7bdeba2c180d5b6fc453a010d4ee2b882a929d"
 HB_TM_DEVICES_ADDON_DOWNLOAD_URL="https://github.com/TomMajor/SmartHome/archive/$HB_TM_DEVICES_ADDON_ARCHIVE_TAG.tar.gz"
 
-PKG_BUILD=120
+PKG_BUILD=121
 
 function throw {
   echo $1

--- a/debmatic.patch
+++ b/debmatic.patch
@@ -1389,3 +1389,15 @@ diff -ruN --no-dereference fw.3.81.5.orig/www/webui/webui.js fw.3.81.5.debmatic/
    },
  
    // For testing only
+diff -ruN --no-dereference fw.3.81.5.orig/www/config/easymodes/etc/hmipChannelConfigDialogs.tcl fw.3.81.5.debmatic/www/config/easymodes/etc/hmipChannelConfigDialogs.tcl
+--- fw.3.81.5.orig/www/config/easymodes/etc/hmipChannelConfigDialogs.tcl
++++ fw.3.81.5.debmatic/www/config/easymodes/etc/hmipChannelConfigDialogs.tcl
+@@ -191,7 +191,7 @@
+      append html "</tr>"
+   }
+ 
+-  if {$deviceIsDrapOrHap} {
++  if { $deviceIsDrapOrHap == "false" } {
+     set param ROUTER_MODULE_ENABLED
+     if { [info exists ps($param)] == 1  } {
+        incr prn


### PR DESCRIPTION
Apply bugfix from RaspberryMatic

https://github.com/jens-maus/RaspberryMatic/commit/569c8b7b5f1614c5064f1 b4dc309bea1d948f486

add 0197-WebUI-Fix-MissingRouterOption WebUI bugfix patch fixing the missing "The device acts as router" since 3.81.x (fixes #3067).

Issue: https://github.com/alexreinert/debmatic/issues/412